### PR TITLE
Generate doc for 3 doxygen versions and provide a script to extract it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,53 @@
-FROM cgal/testsuite-docker:archlinux
+FROM cgal/testsuite-docker:ubuntu
 MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
+RUN  apt-get update \
+  && apt-get install -y bison \
+     git \
+     flex-old \
+     graphviz \
+     python2.7 \
+     python-pyquery \
+     texlive-binaries \
+  && apt-get clean -y \
 
-RUN pacman -Syy && pacman -S --noconfirm \
-    bison \
-    flex \
-    git \
-    graphviz \
-    python2 \
-    python2-pyquery \
-    texlive-bin \
-    && \
-    pacman -Scc --noconfirm
+#RUN pacman -Syy && pacman -S --noconfirm \
+#    bison \
+#    flex \
+ #   git \
+ #   graphviz \
+ #   python2 \
+ #   python2-pyquery \
+ #   texlive-bin \
+ #   && \
+ #   pacman -Scc --noconfirm
 
 USER makepkg
 WORKDIR /tmp/makepkg
-RUN git clone https://github.com/CGAL/doxygen.git && \
-    cd doxygen && ./configure && \
+
+RUN git clone https://github.com/CGAL/doxygen.git cgal_master && \
+    cd cgal_master && \
+    ./configure && \
     make
+
+RUN  apt-get update \
+  && apt-get install -y flex \
+  && apt-get clean -y 
+RUN git clone https://github.com/CGAL/doxygen.git 1_8_13 \
+ && cd 1_8_13 && git checkout release_1_8_13_patched && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make
+
+RUN git clone https://github.com/doxygen/doxygen.git doxygen_master && \
+    cd doxygen_master && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make
+
 USER root
-RUN cd /tmp/makepkg/doxygen && make install
+RUN cd /tmp/makepkg/cgal_master && make install
 
 COPY ./docker_entrypoint.sh /
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN  apt-get update \
      python-pyquery \
      texlive-binaries \
   && apt-get clean -y \
-
-WORKDIR /tmp/makepkg
+RUN mkdir /doxygen
+WORKDIR /doxygen
 
 RUN git clone https://github.com/CGAL/doxygen.git cgal_1_8_4 && \
     cd cgal_1_8_4 && \
@@ -23,10 +23,14 @@ RUN  apt-get update \
   && apt-get clean -y 
 RUN git clone https://github.com/CGAL/doxygen.git 1_8_13 \
  && cd 1_8_13 && git checkout release_1_8_13_patched && \
+    cat VERSION && \
     mkdir build && \
     cd build && \
     cmake .. && \
-    make
+    make 
+
+
+
 
 RUN git clone https://github.com/doxygen/doxygen.git doxygen_master && \
     cd doxygen_master && \
@@ -36,7 +40,7 @@ RUN git clone https://github.com/doxygen/doxygen.git doxygen_master && \
     make
 
 USER root
-RUN cd /tmp/makepkg/cgal_master && make install
+RUN cd cgal_1_8_4 && make install
 
 COPY ./docker_entrypoint.sh /
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,35 +12,38 @@ RUN  apt-get update \
 RUN mkdir /doxygen
 WORKDIR /doxygen
 
-RUN git clone https://github.com/CGAL/doxygen.git cgal_1_8_4 && \
-    cd cgal_1_8_4 && \
+RUN git clone https://github.com/CGAL/doxygen.git cgal_dox && \
+    mkdir cgal_1_8_4 cgal_1_8_13 && \
+    cd cgal_dox && \
     git checkout release_1_8_4_patched && \
     ./configure && \
-    make
+    make && \
+    cp bin/doxygen ../cgal_1_8_4 && \
+    rm VERSION && \
+    git clean -f -X -d
 
 RUN  apt-get update \
   && apt-get install -y flex \
   && apt-get clean -y 
-RUN git clone https://github.com/CGAL/doxygen.git 1_8_13 \
- && cd 1_8_13 && git checkout release_1_8_13_patched && \
-    cat VERSION && \
+RUN cd cgal_dox && git checkout release_1_8_13_patched && \
     mkdir build && \
     cd build && \
     cmake .. && \
-    make 
+    make && \
+    cp bin/doxygen ../../cgal_1_8_13 && \
+    cd ../.. && rm -rf ./cgal_dox
 
 
-
-
-RUN git clone https://github.com/doxygen/doxygen.git doxygen_master && \
-    cd doxygen_master && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make
+#RUN git clone https://github.com/doxygen/doxygen.git doxygen_master && \
+#    cd doxygen_master && \
+#    mkdir build && \
+#    cd build && \
+#    cmake .. && \
+#    make && \
+#    cp bin/doxygen ../../master && \
+#    cd ../.. && rm -rf doxygen_master
 
 USER root
-RUN cd cgal_1_8_4 && make install
 
 COPY ./docker_entrypoint.sh /
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,6 @@ RUN  apt-get update \
      texlive-binaries \
   && apt-get clean -y \
 
-#RUN pacman -Syy && pacman -S --noconfirm \
-#    bison \
-#    flex \
- #   git \
- #   graphviz \
- #   python2 \
- #   python2-pyquery \
- #   texlive-bin \
- #   && \
- #   pacman -Scc --noconfirm
-
 USER makepkg
 WORKDIR /tmp/makepkg
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,14 +27,14 @@ RUN git clone https://github.com/CGAL/doxygen.git cgal_dox && \
 
 
 RUN git clone https://github.com/doxygen/doxygen.git off_dox && \
-    mkdir cgal_1_8_18 && \
+    mkdir cgal_1_9_1 && \
     cd off_dox && \
-    git checkout Release_1_8_18 && \
+    git checkout Release_1_9_1 && \
     mkdir build && \
     cd build && \
     cmake .. && \
     make && \
-    cp bin/doxygen ../../cgal_1_8_18 && \
+    cp bin/doxygen ../../cgal_1_9_1 && \
     cd ../../ && rm -rf off_dox
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN  apt-get update \
      flex \
      graphviz \
      python3 \
-     python2 \
      python3-pyquery \
      texlive-binaries \
   && apt-get clean -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,11 @@ RUN  apt-get update \
      flex \
      graphviz \
      python3 \
+     python2 \
      python3-pyquery \
      texlive-binaries \
-  && apt-get clean -y 
-  
+  && apt-get clean -y
+
 RUN mkdir /doxygen
 WORKDIR /doxygen
 
@@ -21,19 +22,21 @@ RUN git clone https://github.com/CGAL/doxygen.git cgal_dox && \
     cd build && \
     cmake .. && \
     make && \
-    cp bin/doxygen ../../cgal_1_8_13
-    
+    cp bin/doxygen ../../cgal_1_8_13 && \
+    cd ../../ && rm -rf cgal_dox
 
-    
-RUN git clone https://github.com/doxygen/doxygen.git doxygen_1_8_18 && \
-    cd doxygen_1_8_18 && \
+
+
+RUN git clone https://github.com/doxygen/doxygen.git off_dox && \
+    mkdir cgal_1_8_18 && \
+    cd off_dox && \
     git checkout Release_1_8_18 && \
     mkdir build && \
     cd build && \
     cmake .. && \
     make && \
-#     cp bin/doxygen ../../1_8_18 && \
-    cd ../.. && rm -rf doxygen_1_8_18
+    cp bin/doxygen ../../cgal_1_8_18 && \
+    cd ../../ && rm -rf off_dox
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN  apt-get update \
 
 WORKDIR /tmp/makepkg
 
-RUN git clone https://github.com/CGAL/doxygen.git cgal_master && \
-    cd cgal_master && \
+RUN git clone https://github.com/CGAL/doxygen.git cgal_1_8_4 && \
+    cd cgal_1_8_4 && \
+    git checkout release_1_8_4_patched && \
     ./configure && \
     make
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN  apt-get update \
      git \
      flex-old \
      graphviz \
-     python3.5 \
-     python-pyquery \
+     python3 \
+     python3-pyquery \
      texlive-binaries \
   && apt-get clean -y \
 RUN mkdir /doxygen

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,31 +3,29 @@ MAINTAINER Philipp Moeller <bootsarehax@gmail.com>
 RUN  apt-get update \
   && apt-get install -y bison \
      git \
-     flex-old \
+     flex \
      graphviz \
      python3 \
      python3-pyquery \
      texlive-binaries \
-  && apt-get clean -y \
+  && apt-get clean -y 
+  
 RUN mkdir /doxygen
 WORKDIR /doxygen
 
 RUN git clone https://github.com/CGAL/doxygen.git cgal_dox && \
-    mkdir cgal_1_8_4 cgal_1_8_13 && \
+    mkdir cgal_1_8_14 cgal_1_8_13 && \
     cd cgal_dox && \
-    git checkout release_1_8_4_patched && \
-    ./configure && \
-    make && \
-    cp bin/doxygen ../cgal_1_8_4 && \
-    rm VERSION && \
-    git clean -f -X -d
-
-RUN  apt-get update \
-  && apt-get install -y flex \
-  && apt-get clean -y 
-RUN cd cgal_dox && git checkout release_1_8_13_patched && \
+    git checkout release_1_8_14_patched && \
     mkdir build && \
     cd build && \
+    cmake .. && \
+    make && \
+    cp bin/doxygen ../../cgal_1_8_14
+    
+RUN cd cgal_dox && git checkout release_1_8_13_patched && \
+    cd build && \
+    rm -rf ./* && \
     cmake .. && \
     make && \
     cp bin/doxygen ../../cgal_1_8_13 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN  apt-get update \
      git \
      flex-old \
      graphviz \
-     python2.7 \
+     python3.5 \
      python-pyquery \
      texlive-binaries \
   && apt-get clean -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN  apt-get update \
      texlive-binaries \
   && apt-get clean -y \
 
-USER makepkg
 WORKDIR /tmp/makepkg
 
 RUN git clone https://github.com/CGAL/doxygen.git cgal_master && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,32 +14,26 @@ RUN mkdir /doxygen
 WORKDIR /doxygen
 
 RUN git clone https://github.com/CGAL/doxygen.git cgal_dox && \
-    mkdir cgal_1_8_14 cgal_1_8_13 && \
+    mkdir cgal_1_8_13 && \
     cd cgal_dox && \
-    git checkout release_1_8_14_patched && \
+    git checkout release_1_8_13_patched && \
     mkdir build && \
     cd build && \
     cmake .. && \
     make && \
-    cp bin/doxygen ../../cgal_1_8_14
+    cp bin/doxygen ../../cgal_1_8_13
     
-RUN cd cgal_dox && git checkout release_1_8_13_patched && \
+
+    
+RUN git clone https://github.com/doxygen/doxygen.git doxygen_1_8_18 && \
+    cd doxygen_1_8_18 && \
+    git checkout Release_1_8_18 && \
+    mkdir build && \
     cd build && \
-    rm -rf ./* && \
     cmake .. && \
     make && \
-    cp bin/doxygen ../../cgal_1_8_13 && \
-    cd ../.. && rm -rf ./cgal_dox
-
-
-#RUN git clone https://github.com/doxygen/doxygen.git doxygen_master && \
-#    cd doxygen_master && \
-#    mkdir build && \
-#    cd build && \
-#    cmake .. && \
-#    make && \
-#    cp bin/doxygen ../../master && \
-#    cd ../.. && rm -rf doxygen_master
+#     cp bin/doxygen ../../1_8_18 && \
+    cd ../.. && rm -rf doxygen_1_8_18
 
 USER root
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 cgal-doxygen-image
 ==================
 
-This Docker image can be used to build the documentation of CGAL.
+These Docker images can be used to build the documentation of CGAL.
 
 It requires a single user mounted volume containing the CGAL tree to be used, `/mnt/cgal`.
 
@@ -9,10 +9,10 @@ Example Usage:
 
     # Build or pull the image
     docker build -t cgal-doxygen .
-    docker run -v /path/to/cgal:/mnt/cgal \
-               cgal-doxygen
+    docker run -v /path/to/cgal:/mnt/cgal -t -i \
+               cgal-doxygen /bin/bash/docker_entrypoint.sh cgal_build_documentation
 
     # Extract the created documentation
-    docker cp container_id:/cgal_build/doc_output /tmp/doc_output
+    docker cp container_id:/[cgal_build_1_8_13 or cgal_build_doxygen_master or cgal_build_master]/doc_output /tmp/doc_output
     # Extract the documentation testsuite
-    docker cp container_id:/cgal_build/doc_log /tmp/doc_log
+    docker cp container_id:/[cgal_build_1_8_13/doc_output or cgal_build_doxygen_master or cgal_build_master]/doc_log /tmp/doc_log

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Example Usage:
     where 
     - `path_to_image` is the absolute path to the directory containing the dockerfile
     - `path_to_cgal` is the absolute path to the root directory of CGAL
-    - `path_to_publish_dir` is the absolute path to the output directory, that will contian the 3 versions and the result of the comparison. 
+    - `path_to_publish_dir` is the absolute path to the output directory, that will contain the 3 versions and the result of the comparison. 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,9 @@ It requires a single user mounted volume containing the CGAL tree to be used, `/
 
 Example Usage:
 
-    # Build or pull the image
-    docker build -t cgal-doxygen .
-    docker run -v /path/to/cgal:/mnt/cgal -t -i \
-               cgal-doxygen /bin/bash /docker_entrypoint.sh cgal_build_documentation
-
-    # Extract the created documentation
-    docker cp container_id:/[cgal_build_1_8_13 or cgal_build_doxygen_master or cgal_build_master]/doc_output /tmp/doc_output
-    # Extract the documentation testsuite
-    docker cp container_id:/[cgal_build_1_8_13/doc_output or cgal_build_doxygen_master or cgal_build_master]/doc_log /tmp/doc_log
+    #call the script 
+    `./generate_documentation.sh <path_to_image> <path_to_cgal> <path_to_publish_dir>`
+    where 
+    - `path_to_image` is the absolute path to the directory containing the dockerfile
+    - `path_to_cgal` is the absolute path to the root directory of CGAL
+    - `path_to_publish_dir` is the absolute path to the output directory, that will contian the 3 versions and the result of the comparison. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 cgal-doxygen-image
 ==================
 
-These Docker images can be used to build the documentation of CGAL.
+This Docker image can be used to build the documentation of CGAL.
 
 It requires a single user mounted volume containing the CGAL tree to be used, `/mnt/cgal`.
 
@@ -10,7 +10,7 @@ Example Usage:
     # Build or pull the image
     docker build -t cgal-doxygen .
     docker run -v /path/to/cgal:/mnt/cgal -t -i \
-               cgal-doxygen /bin/bash/docker_entrypoint.sh cgal_build_documentation
+               cgal-doxygen /bin/bash /docker_entrypoint.sh cgal_build_documentation
 
     # Extract the created documentation
     docker cp container_id:/[cgal_build_1_8_13 or cgal_build_doxygen_master or cgal_build_master]/doc_output /tmp/doc_output

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -4,9 +4,9 @@ set -e
 if [ "$1" = 'cgal_build_documentation' ]; then
     ln -s /bin/python3 /bin/python
     cd /mnt/cgal/Documentation/doc/scripts/
-    mkdir -p $PWD/doc_1_8_13
-    mkdir -p $PWD/doc_1_8_18
-    bash ./process_doc.sh "/doxygen/cgal_1_8_13/doxygen" "/doxygen/cgal_1_8_18/doxygen" /testsuite_out
+    mkdir -p $PWD/doc_1_9_1
+    mkdir -p $PWD/doc_1_9_1
+    bash ./process_doc.sh "/doxygen/cgal_1_8_13/doxygen" "/doxygen/cgal_1_9_1/doxygen" /testsuite_out
 else
     exec "$@"
 fi

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -2,30 +2,35 @@
 set -e
 
 if [ "$1" = 'cgal_build_documentation' ]; then
-    mkdir -p /cgal_build_master
+    mkdir -p /cgal_build_1_8_4
     mkdir -p /cgal_build_1_8_13
     mkdir -p /cgal_build_doxygen_master
-    cd /cgal_build_master
-    cmake -DBUILD_DOC:BOOL=ON \
-          -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
-          /mnt/cgal
+    cd /cgal_build_1_8_4
+    cmake -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
+          /mnt/cgal/Documentation/doc
+    make doc
     make doc
     make Documentation_test
-    cd ../cgal_build_1_8_13
-    cmake -DBUILD_DOC:BOOL=ON \
-          -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
-          -DDOXYGEN_EXECUTABLE:FILEPATH='/tmp/makepkg/1_8_13/build/bin/doxygen' \
-          /mnt/cgal
+    python "/mnt/cgal/Documentation/doc/scripts/testsuite.py"  --doc-log-dir "./doc_log" --output-dir "./doc_output" --cgal-version 1 --publish "/testsuite_out/1_8_4"
+cd /doxygen
+ls
+    cd /cgal_build_1_8_13
+    cmake -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
+          -DDOXYGEN_EXECUTABLE:FILEPATH='/doxygen/1_8_13/build/bin/doxygen' \
+          /mnt/cgal/Documentation/doc
+    make doc
     make doc
     make Documentation_test
+    python "/mnt/cgal/Documentation/doc/scripts/testsuite.py"  --doc-log-dir "./doc_log" --output-dir "./doc_output" --cgal-version 1 --publish "/testsuite_out/1_8_13"
     cd ../cgal_build_doxygen_master
-    cmake -DBUILD_DOC:BOOL=ON \
-          -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
-          -DDOXYGEN_EXECUTABLE:FILEPATH='/tmp/makepkg/doxygen_master/build/bin/doxygen' \
-          /mnt/cgal
+    cmake -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
+          -DDOXYGEN_EXECUTABLE:FILEPATH='/doxygen/doxygen_master/build/bin/doxygen' \
+          /mnt/cgal/Documentation/doc
+    
+    make doc
     make doc
     make Documentation_test
-
+    python "/mnt/cgal/Documentation/doc/scripts/testsuite.py"  --doc-log-dir "./doc_log" --output-dir "./doc_output" --cgal-version 1 --publish "/testsuite_out/doxygen_master"
 else
     exec "$@"
 fi

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -2,11 +2,12 @@
 set -e
 
 if [ "$1" = 'cgal_build_documentation' ]; then
+    ln -s /bin/python3 /bin/python
     cd /mnt/cgal/Documentation/doc/scripts/
     mkdir -p $PWD/testsuite_out
     mkdir -p $PWD/doc_1_8_14 
-    mkdir -p $PWD/doc_1_8_13
-    bash ./process_doc.sh "/doxygen/cgal_1_8_13/doxygen" "/doxygen/cgal_1_8_14/doxygen" $PWD/testsuite_out
+    mkdir -p $PWD/doc_1_8_18
+    bash ./process_doc.sh "/doxygen/cgal_1_8_13/doxygen" "/doxygen/1_8_18/doxygen" $PWD/testsuite_out
 else
     exec "$@"
 fi

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -4,9 +4,9 @@ set -e
 if [ "$1" = 'cgal_build_documentation' ]; then
     cd /mnt/cgal/Documentation/doc/scripts/
     mkdir -p $PWD/testsuite_out
-    mkdir -p $PWD/doc_1_8_4 
+    mkdir -p $PWD/doc_1_8_14 
     mkdir -p $PWD/doc_1_8_13
-    bash ./process_doc.sh "/doxygen/cgal_1_8_4/doxygen" "/doxygen/cgal_1_8_13/doxygen" $PWD/testsuite_out
+    bash ./process_doc.sh "/doxygen/cgal_1_8_13/doxygen" "/doxygen/cgal_1_8_14/doxygen" $PWD/testsuite_out
 else
     exec "$@"
 fi

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -4,10 +4,9 @@ set -e
 if [ "$1" = 'cgal_build_documentation' ]; then
     ln -s /bin/python3 /bin/python
     cd /mnt/cgal/Documentation/doc/scripts/
-    mkdir -p $PWD/testsuite_out
-    mkdir -p $PWD/doc_1_8_14 
+    mkdir -p $PWD/doc_1_8_13
     mkdir -p $PWD/doc_1_8_18
-    bash ./process_doc.sh "/doxygen/cgal_1_8_13/doxygen" "/doxygen/1_8_18/doxygen" $PWD/testsuite_out
+    bash ./process_doc.sh "/doxygen/cgal_1_8_13/doxygen" "/doxygen/cgal_1_8_18/doxygen" /testsuite_out
 else
     exec "$@"
 fi

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -2,13 +2,30 @@
 set -e
 
 if [ "$1" = 'cgal_build_documentation' ]; then
-    mkdir /cgal_build
-    cd /cgal_build
+    mkdir -p /cgal_build_master
+    mkdir -p /cgal_build_1_8_13
+    mkdir -p /cgal_build_doxygen_master
+    cd /cgal_build_master
     cmake -DBUILD_DOC:BOOL=ON \
           -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
           /mnt/cgal
     make doc
     make Documentation_test
+    cd ../cgal_build_1_8_13
+    cmake -DBUILD_DOC:BOOL=ON \
+          -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
+          -DDOXYGEN_EXECUTABLE:FILEPATH='/tmp/makepkg/1_8_13/build/bin/doxygen' \
+          /mnt/cgal
+    make doc
+    make Documentation_test
+    cd ../cgal_build_doxygen_master
+    cmake -DBUILD_DOC:BOOL=ON \
+          -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
+          -DDOXYGEN_EXECUTABLE:FILEPATH='/tmp/makepkg/doxygen_master/build/bin/doxygen' \
+          /mnt/cgal
+    make doc
+    make Documentation_test
+
 else
     exec "$@"
 fi

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 if [ "$1" = 'cgal_build_documentation' ]; then
     ln -s /bin/python3 /bin/python
     cd /mnt/cgal/Documentation/doc/scripts/
-    mkdir -p $PWD/doc_1_9_1
+    mkdir -p $PWD/doc_1_8_13
     mkdir -p $PWD/doc_1_9_1
     bash ./process_doc.sh "/doxygen/cgal_1_8_13/doxygen" "/doxygen/cgal_1_9_1/doxygen" /testsuite_out
 else

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -2,35 +2,8 @@
 set -e
 
 if [ "$1" = 'cgal_build_documentation' ]; then
-    mkdir -p /cgal_build_1_8_4
-    mkdir -p /cgal_build_1_8_13
-    mkdir -p /cgal_build_doxygen_master
-    cd /cgal_build_1_8_4
-    cmake -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
-          /mnt/cgal/Documentation/doc
-    make doc
-    make doc
-    make Documentation_test
-    python "/mnt/cgal/Documentation/doc/scripts/testsuite.py"  --doc-log-dir "./doc_log" --output-dir "./doc_output" --cgal-version 1 --publish "/testsuite_out/1_8_4"
-cd /doxygen
-ls
-    cd /cgal_build_1_8_13
-    cmake -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
-          -DDOXYGEN_EXECUTABLE:FILEPATH='/doxygen/1_8_13/build/bin/doxygen' \
-          /mnt/cgal/Documentation/doc
-    make doc
-    make doc
-    make Documentation_test
-    python "/mnt/cgal/Documentation/doc/scripts/testsuite.py"  --doc-log-dir "./doc_log" --output-dir "./doc_output" --cgal-version 1 --publish "/testsuite_out/1_8_13"
-    cd ../cgal_build_doxygen_master
-    cmake -DCGAL_DOC_CREATE_LOGS:BOOL=ON \
-          -DDOXYGEN_EXECUTABLE:FILEPATH='/doxygen/doxygen_master/build/bin/doxygen' \
-          /mnt/cgal/Documentation/doc
-    
-    make doc
-    make doc
-    make Documentation_test
-    python "/mnt/cgal/Documentation/doc/scripts/testsuite.py"  --doc-log-dir "./doc_log" --output-dir "./doc_output" --cgal-version 1 --publish "/testsuite_out/doxygen_master"
+    cd /mnt/cgal/Documentation/doc/scripts/
+    bash ./process_doc.sh "/doxygen/cgal_1_8_4/doxygen" "/doxygen/cgal_1_8_13/doxygen" /testsuite_out
 else
     exec "$@"
 fi

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -3,7 +3,10 @@ set -e
 
 if [ "$1" = 'cgal_build_documentation' ]; then
     cd /mnt/cgal/Documentation/doc/scripts/
-    bash ./process_doc.sh "/doxygen/cgal_1_8_4/doxygen" "/doxygen/cgal_1_8_13/doxygen" /testsuite_out
+    mkdir -p $PWD/testsuite_out
+    mkdir -p $PWD/doc_1_8_4 
+    mkdir -p $PWD/doc_1_8_13
+    bash ./process_doc.sh "/doxygen/cgal_1_8_4/doxygen" "/doxygen/cgal_1_8_13/doxygen" $PWD/testsuite_out
 else
     exec "$@"
 fi

--- a/generate_documentation.sh
+++ b/generate_documentation.sh
@@ -14,7 +14,7 @@ docker run -v "$PATH_TO_CGAL":/mnt/cgal -t cgal_doc /docker_entrypoint.sh cgal_b
 #run second time to link
 docker run -v "$PATH_TO_CGAL":/mnt/cgal -t cgal_doc /docker_entrypoint.sh cgal_build_documentation
 #create output directories
-DIR_LIST=(master 1_8_13 doxygen_master)
+DIR_LIST=(1_8_4 1_8_13 doxygen_master)
 DOCKER_ID=$(docker ps -l -aqf "ancestor=cgal_doc")
 for dir in ${DIR_LIST[*]}
 do

--- a/generate_documentation.sh
+++ b/generate_documentation.sh
@@ -1,20 +1,16 @@
 #!/bin/bash
 set -e
-#Must be called from the wanted output directory
-
 #Path to directory containing Dockerfile
 PATH_TO_IMAGE="$1"
 #Path to CGAL root directory
 PATH_TO_CGAL="$2"
+#Path to publish dir
+PATH_TO_PUBLISH="$3" 
 
 #build docker image
-docker build -t cgal_doc $PATH_TO_IMAGE
+docker build -t cgal_documentation:comparison $PATH_TO_IMAGE
 #generate documentation
 mkdir -p "$PWD/results"
-cd ./results
-mkdir -p 1_8_4
-mkdir -p 1_8_13
-mkdir -p doxygen_master
 cd ..
 
-docker run -v "$PATH_TO_CGAL":/mnt/cgal -v "$PWD/results":/testsuite_out -t cgal_doc /docker_entrypoint.sh cgal_build_documentation
+docker run -v "$PATH_TO_CGAL":/mnt/cgal -v "$PATH_TO_PUBLISH":/testsuite_out -t cgal_documentation:comparison

--- a/generate_documentation.sh
+++ b/generate_documentation.sh
@@ -8,11 +8,11 @@ PATH_TO_IMAGE="$1"
 PATH_TO_CGAL="$2"
 
 #build docker image
-#docker build -t cgal_doc $PATH_TO_IMAGE
+docker build -t cgal_doc $PATH_TO_IMAGE
 #generate documentation
-#docker run -v "$PATH_TO_CGAL":/mnt/cgal -t cgal_doc /docker_entrypoint.sh cgal_build_documentation
+docker run -v "$PATH_TO_CGAL":/mnt/cgal -t cgal_doc /docker_entrypoint.sh cgal_build_documentation
 #run second time to link
-#docker run -v "$PATH_TO_CGAL":/mnt/cgal -t cgal_doc /docker_entrypoint.sh cgal_build_documentation
+docker run -v "$PATH_TO_CGAL":/mnt/cgal -t cgal_doc /docker_entrypoint.sh cgal_build_documentation
 #create output directories
 DIR_LIST=(master 1_8_13 doxygen_master)
 DOCKER_ID=$(docker ps -l -aqf "ancestor=cgal_doc")

--- a/generate_documentation.sh
+++ b/generate_documentation.sh
@@ -10,7 +10,4 @@ PATH_TO_PUBLISH="$3"
 #build docker image
 docker build -t cgal_documentation:comparison $PATH_TO_IMAGE
 #generate documentation
-mkdir -p "$PWD/results"
-cd ..
-
 docker run -v "$PATH_TO_CGAL":/mnt/cgal -v "$PATH_TO_PUBLISH":/testsuite_out -t cgal_documentation:comparison

--- a/generate_documentation.sh
+++ b/generate_documentation.sh
@@ -10,18 +10,11 @@ PATH_TO_CGAL="$2"
 #build docker image
 docker build -t cgal_doc $PATH_TO_IMAGE
 #generate documentation
-docker run -v "$PATH_TO_CGAL":/mnt/cgal -t cgal_doc /docker_entrypoint.sh cgal_build_documentation
-#run second time to link
-docker run -v "$PATH_TO_CGAL":/mnt/cgal -t cgal_doc /docker_entrypoint.sh cgal_build_documentation
-#create output directories
-DIR_LIST=(1_8_4 1_8_13 doxygen_master)
-DOCKER_ID=$(docker ps -l -aqf "ancestor=cgal_doc")
-for dir in ${DIR_LIST[*]}
-do
-  mkdir -p $dir
-  #extract documentation to corresponding directories
-  docker cp "$DOCKER_ID":/"cgal_build_$dir/doc_output" "./$dir"
-  docker cp "$DOCKER_ID":"/cgal_build_$dir/doc_log" "./$dir"
-  mkdir -p "$dir/testsuite_out"
-  python "$PATH_TO_CGAL/Documentation/doc/scripts/testsuite.py"  --doc-log-dir "$dir/doc_log" --output-dir "$dir/doc_output" --cgal-version 1 --publish "$PWD/$dir/testsuite_out"
-done
+mkdir -p "$PWD/results"
+cd ./results
+mkdir -p 1_8_4
+mkdir -p 1_8_13
+mkdir -p doxygen_master
+cd ..
+
+docker run -v "$PATH_TO_CGAL":/mnt/cgal -v "$PWD/results":/testsuite_out -t cgal_doc /docker_entrypoint.sh cgal_build_documentation

--- a/generate_documentation.sh
+++ b/generate_documentation.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+#Must be called from the wanted output directory
+
+#Path to directory containing Dockerfile
+PATH_TO_IMAGE="$1"
+#Path to CGAL root directory
+PATH_TO_CGAL="$2"
+
+#build docker image
+#docker build -t cgal_doc $PATH_TO_IMAGE
+#generate documentation
+#docker run -v "$PATH_TO_CGAL":/mnt/cgal -t cgal_doc /docker_entrypoint.sh cgal_build_documentation
+#run second time to link
+#docker run -v "$PATH_TO_CGAL":/mnt/cgal -t cgal_doc /docker_entrypoint.sh cgal_build_documentation
+#create output directories
+DIR_LIST=(master 1_8_13 doxygen_master)
+DOCKER_ID=$(docker ps -l -aqf "ancestor=cgal_doc")
+for dir in ${DIR_LIST[*]}
+do
+  mkdir -p $dir
+  #extract documentation to corresponding directories
+  docker cp "$DOCKER_ID":/"cgal_build_$dir/doc_output" "./$dir"
+  docker cp "$DOCKER_ID":"/cgal_build_$dir/doc_log" "./$dir"
+  mkdir -p "$dir/testsuite_out"
+  python "$PATH_TO_CGAL/Documentation/doc/scripts/testsuite.py"  --doc-log-dir "$dir/doc_log" --output-dir "$dir/doc_output" --cgal-version 1 --publish "$PWD/$dir/testsuite_out"
+done


### PR DESCRIPTION
Fix CGAL/cgal#1800.

This PR changes the container so it generates the documentation for three different versions of doxygen :
- the master of the cgal fork
- the branch release_1_8_13_patched from the cgal fork
- the master of doxygen

It also provides a script to extract this documentation. The script generate_documentation.sh must be called from the directory in which the doc will be extracted. Its first argument is the path to the Dockerfile of this container, and its second argument is the path the the CGAL directory from which the documentation will be built.

Depends on https://github.com/CGAL/cgal/pull/4448